### PR TITLE
fix: uncompressed shared libraries alignement

### DIFF
--- a/dcc.py
+++ b/dcc.py
@@ -207,9 +207,10 @@ def zipalign(input_apk, output_apk):
 
     command = [
         "zipalign",
-        "-p",
-        "-f",
+        "-P",
         "16",
+        "-f",
+        "4",
         input_apk,
         output_apk,
     ]


### PR DESCRIPTION
The "-p" option forces a 4 KB page alignment for uncompressed .so files.
It should be replaced with: "-P", "16".

Only .so files require a 16 KB alignment ; a 4 KB alignment is sufficient for other uncompressed files.
